### PR TITLE
Change from UUID to CUID model of unique identifiers

### DIFF
--- a/kant/events/models.py
+++ b/kant/events/models.py
@@ -2,7 +2,7 @@ from json import JSONDecoder, JSONEncoder
 from datetime import datetime
 from decimal import Decimal
 from abc import ABCMeta
-from uuid import uuid1, UUID
+from cuid import cuid
 from pprint import pformat
 from collections import MutableMapping
 import json
@@ -31,15 +31,13 @@ class UUIDField(Field):
         self.primary_key = primary_key
         super().__init__(*args, **kwargs)
         if self.primary_key:
-            self.default = lambda: uuid1()
+            self.default = lambda: cuid()
 
     def encode(self, value):
         return str(value)
 
     def parse(self, value):
-        if isinstance(value, UUID):
-            return value
-        return UUID(value)
+        return value
 
 
 class DecimalField(Field):

--- a/kant/repositories.py
+++ b/kant/repositories.py
@@ -14,7 +14,7 @@ class EventStoreRepository:
     def __init__(self, session, event_store_name):
         self.session = session
         self.EventStore = sa.Table(event_store_name, sa.MetaData(),  # NOQA
-            sa.Column('id', UUIDType(binary=False), primary_key=True),
+            sa.Column('id', sa.String),
             sa.Column('version', sa.Integer),
             sa.Column('data', JSONB),
             sa.Column('metadata', JSONB),

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         'sqlalchemy_utils',
         'python-dateutil',
         'inflection',
+	'cuid.py',
     ],
     setup_requires=[
         'pytest-runner',


### PR DESCRIPTION
The type of unique identifier generated from UUID to CUID has changed.
This change reduces the risk of collision of identifiers for database applications with horizontal scalability and volume of new identifiers per month in the order of 1 to 10 million.

based on:

https://github.com/ericelliott/cuid/issues/22
